### PR TITLE
Small simplification removing extra layer (closes #8)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,9 +4,13 @@
 
 	* src/Makevars: Removed as we do not set a compilation standard
 
+2022-08-21  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/align.cpp (align_{,idx}_{duration,period}): Small simplification
+
 2022-03-10  Dirk Eddelbuettel  <edd@debian.org>
 
-	* README.md: Add badges, polish one example (thanks, @janogorecki)
+	* README.md: Add badges, polish one example (thanks, @jangorecki)
 
 2022-03-06  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -346,23 +346,16 @@ Rcpp::List align_duration(const Rcpp::NumericVector& x,         // nanotime vect
                           const Rcpp::LogicalVector& eopen,     // end open
                           const Rcpp::Function func)            // function to apply (character)
 {
-  try {
-    return align_func_duration(reinterpret_cast<const nanotime::dtime*>(&x[0]),
-                               x.size(),
-                               reinterpret_cast<const nanotime::dtime*>(&y[0]),
-                               y.size(),
-                               xdata,
-                               ConstPseudoVectorDuration(start),
-                               ConstPseudoVectorDuration(end),
-                               ConstPseudoVectorLgl(sopen),
-                               ConstPseudoVectorLgl(eopen),
-                               Rcpp::Function(func));
-  } catch(std::exception &ex) {	
-    forward_exception_to_r(ex);
-  } catch(...) { 
-    ::Rf_error("c++ exception (unknown reason)"); 
-  }
-  return R_NilValue;         // not reached
+  return align_func_duration(reinterpret_cast<const nanotime::dtime*>(&x[0]),
+                             x.size(),
+                             reinterpret_cast<const nanotime::dtime*>(&y[0]),
+                             y.size(),
+                             xdata,
+                             ConstPseudoVectorDuration(start),
+                             ConstPseudoVectorDuration(end),
+                             ConstPseudoVectorLgl(sopen),
+                             ConstPseudoVectorLgl(eopen),
+                             Rcpp::Function(func));
 }
 
 
@@ -377,24 +370,17 @@ Rcpp::List align_period(const Rcpp::NumericVector& x,         // nanotime vector
                         const Rcpp::Function func,            // function to apply (character)
                         const Rcpp::CharacterVector tz)       // timezone
 {
-  try {
-    return align_func_period(reinterpret_cast<const nanotime::dtime*>(&x[0]),
-                             x.size(),
-                             reinterpret_cast<const nanotime::dtime*>(&y[0]),
-                             y.size(),
-                             xdata,
-                             ConstPseudoVectorPrd(start),
-                             ConstPseudoVectorPrd(end),
-                             ConstPseudoVectorLgl(sopen),
-                             ConstPseudoVectorLgl(eopen),
-                             Rcpp::Function(func),
-                             ConstPseudoVectorChar(tz));
-  } catch(std::exception &ex) {	
-    forward_exception_to_r(ex);
-  } catch(...) { 
-    ::Rf_error("c++ exception (unknown reason)");
-  }
-  return R_NilValue;         // not reached
+  return align_func_period(reinterpret_cast<const nanotime::dtime*>(&x[0]),
+                           x.size(),
+                           reinterpret_cast<const nanotime::dtime*>(&y[0]),
+                           y.size(),
+                           xdata,
+                           ConstPseudoVectorPrd(start),
+                           ConstPseudoVectorPrd(end),
+                           ConstPseudoVectorLgl(sopen),
+                           ConstPseudoVectorLgl(eopen),
+                           Rcpp::Function(func),
+                           ConstPseudoVectorChar(tz));
 }
 
 
@@ -406,21 +392,14 @@ Rcpp::NumericVector align_idx_duration(const Rcpp::NumericVector& x,     // nano
                                        const Rcpp::LogicalVector& sopen, // start open
                                        const Rcpp::LogicalVector& eopen) // end open
 {
-  try {
-    return align_idx_helper_duration(reinterpret_cast<const nanotime::dtime*>(&x[0]),
-                                     x.size(),
-                                     reinterpret_cast<const nanotime::dtime*>(&y[0]),
-                                     y.size(),
-                                     ConstPseudoVectorDuration(start),
-                                     ConstPseudoVectorDuration(end),
-                                     ConstPseudoVectorLgl(sopen),
-                                     ConstPseudoVectorLgl(eopen));
-  } catch(std::exception &ex) {	
-    forward_exception_to_r(ex);
-  } catch(...) { 
-    ::Rf_error("c++ exception (unknown reason)"); 
-  }
-  return R_NilValue;             // not reached
+  return align_idx_helper_duration(reinterpret_cast<const nanotime::dtime*>(&x[0]),
+                                   x.size(),
+                                   reinterpret_cast<const nanotime::dtime*>(&y[0]),
+                                   y.size(),
+                                   ConstPseudoVectorDuration(start),
+                                   ConstPseudoVectorDuration(end),
+                                   ConstPseudoVectorLgl(sopen),
+                                   ConstPseudoVectorLgl(eopen));
 }
 
 
@@ -433,22 +412,15 @@ Rcpp::NumericVector align_idx_period(const Rcpp::NumericVector& x,     // nanoti
                                      const Rcpp::LogicalVector& eopen, // end open
                                      const Rcpp::CharacterVector& tz)  // timezone
 {
-  try {
-    return align_idx_helper_period(reinterpret_cast<const nanotime::dtime*>(&x[0]),
-                                   x.size(),
-                                   reinterpret_cast<const nanotime::dtime*>(&y[0]),
-                                   y.size(),
-                                   ConstPseudoVectorPrd(start),
-                                   ConstPseudoVectorPrd(end),
-                                   ConstPseudoVectorLgl(sopen),
-                                   ConstPseudoVectorLgl(eopen),
-                                   ConstPseudoVectorChar(tz));
-  } catch(std::exception &ex) {	
-    forward_exception_to_r(ex);
-  } catch(...) { 
-    ::Rf_error("c++ exception (unknown reason)"); 
-  }
-  return R_NilValue;             // not reached
+  return align_idx_helper_period(reinterpret_cast<const nanotime::dtime*>(&x[0]),
+                                 x.size(),
+                                 reinterpret_cast<const nanotime::dtime*>(&y[0]),
+                                 y.size(),
+                                 ConstPseudoVectorPrd(start),
+                                 ConstPseudoVectorPrd(end),
+                                 ConstPseudoVectorLgl(sopen),
+                                 ConstPseudoVectorLgl(eopen),
+                                 ConstPseudoVectorChar(tz));
 }
 
 


### PR DESCRIPTION
This PR removes the `try` / `catch` block from four alignment helpers. `Rcpp` automatically adds such a block by expanding the `BEGIN_RCPP` and `END_RCPP` macros inserted by `compileAttributes()`, and also uses an approach to report the error back that has seen some refinement.  This should help with the small `valgrind` leak reported at CRAN -- and does so in local testing.

