### PR TITLE
No longer set a default compilation standard 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2023-03-22  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Versio, Date): Roll minor version and date
+
 	* src/Makevars: Removed as we do not set a compilation standard
 
 2022-03-10  Dirk Eddelbuettel  <edd@debian.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-03-22  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/Makevars: Removed as we do not set a compilation standard
+
 2022-03-10  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Add badges, polish one example (thanks, @janogorecki)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: dtts
 Type: Package
 Title: 'data.table' Time-Series
-Version: 0.1.0
-Date: 2022-03-06
+Version: 0.1.0.1
+Date: 2023-03-22
 Author: Dirk Eddelbuettel and Leonardo Silvestri
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: High-frequency time-series support via 'nanotime' and 'data.table'.

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,2 +1,0 @@
-## We want C++11 
-CXX_STD = CXX11


### PR DESCRIPTION
Just like in [nanotime PR #114](https://github.com/eddelbuettel/nanotime/pull/114), we can remove the `CXX_STD` setting as the right thing happens by default.

We should make some time for the other branch / still draft PR with valgrind nag.  I'll try to poke one of these days. I just re-confirmed it is still 'live'.