### PR TITLE
Release 0.1.1

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+comment: false
+coverage:
+  status:
+    project:
+      default:
+        target: 70%    # the (on purpose low) required coverage value
+        threshold: 10% # the permitted delta in hitting the target
+    patch:
+      default:
+        target: 0%     # the (on purpose low) required coverage value

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-08-08  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Release 0.1.1
+
 2023-05-15 Leonardo Silvestri <lsilvestri@ztsdb.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version and date

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: dtts
 Type: Package
 Title: 'data.table' Time-Series
-Version: 0.1.0.4
-Date: 2023-05-15
+Version: 0.1.1
+Date: 2023-08-08
 Author: Dirk Eddelbuettel and Leonardo Silvestri
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: High-frequency time-series support via 'nanotime' and 'data.table'.

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,6 +3,19 @@
 \newcommand{\ghpr}{\href{https://github.com/eddelbuettel/dtts/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/eddelbuettel/dtts/issues/#1}{##1}}
 
+\section{Changes in version 0.1.1 (2023-08-08)}{
+  \itemize{
+    \item A simplifcation was applied to the C++ interface glue code
+    (\ghpr{9} fixing \ghit{8})
+    \item The package no longer enforces the C++11 compilation standard
+    (\ghpr{10})
+    \item An uninitialized memory read has been correct (\ghpr{11})
+    \item A new function \code{ops} has been added (\ghpr{12})
+    \item Function names no longer start with a dot (\ghpr{13})
+    \item Arbitrary index columns are now supported (\ghpr{13})
+  }
+}
+
 \section{Changes in version 0.1.0 (2022-03-06)}{
   \itemize{
     \item Initial CRAN upload.


### PR DESCRIPTION
Here is tiny PR preparing for the CRAN reopen.  It basically just adds the NEWS paragraph and sets the new version.

We were fighting at some point with code coverage complaining about too many changes in PR.  I had parameter files in other repos so I tried this.  We can try committing it along, if it doesn't work out we can always tweak and/or remove.

I suggest we leave this open and do not merge til we hear from CRAN, which should be simple enough though given the one open issue (we address many PRs ago) it will require one email handshake back and forth which usually takes are few hours.