### PR TITLE
Make sure localtime_s is used on Windows even with LLVM.

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -24,13 +24,13 @@ template<typename Clock, typename Duration>
 std::ostream &operator<<(std::ostream &stream,
                          const std::chrono::time_point<Clock, Duration> &time_point) {
   const time_t time = Clock::to_time_t(time_point);
-#if (__GNUC__ > 4 || ((__GNUC__ == 4) && __GNUC_MINOR__ > 8 && __GNUC_REVISION__ > 1))
+#if (__GNUC__ > 4 || defined(__WIN32) || ((__GNUC__ == 4) && __GNUC_MINOR__ > 8 && __GNUC_REVISION__ > 1))
   // Maybe the put_time will be implemented later?
   struct tm tm;
   // thanks to https://stackoverflow.com/a/38034148/143305 for the next test
   #if defined(__unix__)
   localtime_r(&time, &tm);
-  #elif defined(_MSC_VER)
+  #elif defined(_MSC_VER) || defined(__WIN32)
   localtime_s(&tm, &time);
   #endif
   return stream << std::put_time(&tm, "%c"); // Print standard date&time


### PR DESCRIPTION
This makes sure that locatime_s is used on Windows even with LLVM. localtime_s is present on Windows with MSVC as well as mingw-w64, regardless of the compiler.

The previous form of the conditional does not work, because clang identifies itself as a very old gcc (4.2 by now), so ctime_r is used instead. But, ctime_r is (by default) not available on Windows. Mingw-w64 has it, but it has to be enabled via some special defines, so it seems cleaner to me to fix the condition to use localtime_s.

With this fix, the package builds and checks fine on my Windows/aarch64 using LLVM 17.